### PR TITLE
Fix package name typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ features we needed. If the library is missing a feature from the API, raise an i
 To install go-onfido, use `go get`:
 
 ```
-go get github.com/uw-labs/go-onfio
+go get github.com/uw-labs/go-onfido
 ```
 
 ## Usage


### PR DESCRIPTION
README.md pointed to the wrong (missing) GitHub repository.
Fix the link.