### PR TITLE
Added Proof of Address Report Name

### DIFF
--- a/report.go
+++ b/report.go
@@ -12,6 +12,7 @@ const (
 	ReportNameDocument         ReportName = "document"
 	ReportNameFacialSimilarity ReportName = "facial_similarity"
 	ReportNameStreetLevel      ReportName = "street_level"
+	ReportNameProofOfAddress   ReportName = "proof_of_address"
 
 	ReportResultClear        ReportResult = "clear"
 	ReportResultConsider     ReportResult = "consider"


### PR DESCRIPTION
Added the onfido proof_of_address Report Name - this value came from Onfido Support, it's not yet in their documentation, we have it working in production.