### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ features we needed. If the library is missing a feature from the API, raise an i
 To install go-onfido, use `go get`:
 
 ```
-go get github.com/uw-labs/go-onfio
+go get github.com/uw-labs/go-onfido
 ```
 
 ## Usage

--- a/check.go
+++ b/check.go
@@ -55,7 +55,7 @@ type Check struct {
 	FormURI     string      `json:"form_uri,omitempty"`
 	RedirectURI string      `json:"redirect_uri,omitempty"`
 	ResultsURI  string      `json:"results_uri,omitempty"`
-	Reports     []*Report   `json:"reports,omitempty"`
+	Reports     []string    `json:"reports,omitempty"`
 	Tags        []string    `json:"tags,omitempty"`
 }
 

--- a/check.go
+++ b/check.go
@@ -59,6 +59,25 @@ type Check struct {
 	Tags        []string    `json:"tags,omitempty"`
 }
 
+// CheckRetrieved represents a check in the Onfido API which has been retrieved.
+// This is subtly different to the Check type above, as the Reports slice
+// is just a string of Report IDs, not fully expanded Report objects.
+// See https://documentation.onfido.com/?shell#check-object (Shell)
+type CheckRetrieved struct {
+	ID          string      `json:"id,omitempty"`
+	CreatedAt   *time.Time  `json:"created_at,omitempty"`
+	Href        string      `json:"href,omitempty"`
+	Type        CheckType   `json:"type,omitempty"`
+	Status      CheckStatus `json:"status,omitempty"`
+	Result      CheckResult `json:"result,omitempty"`
+	DownloadURI string      `json:"download_uri,omitempty"`
+	FormURI     string      `json:"form_uri,omitempty"`
+	RedirectURI string      `json:"redirect_uri,omitempty"`
+	ResultsURI  string      `json:"results_uri,omitempty"`
+	Reports     []string    `json:"reports,omitempty"`
+	Tags        []string    `json:"tags,omitempty"`
+}
+
 // Checks represents a list of checks in Onfido API
 type Checks struct {
 	Checks []*Check `json:"checks"`
@@ -84,15 +103,54 @@ func (c *Client) CreateCheck(ctx context.Context, applicantID string, cr CheckRe
 
 // GetCheck retrieves a check for the provided applicant by its ID.
 // see https://documentation.onfido.com/?shell#retrieve-check
-func (c *Client) GetCheck(ctx context.Context, applicantID, id string) (*Check, error) {
+func (c *Client) GetCheck(ctx context.Context, applicantID, id string) (*CheckRetrieved, error) {
 	req, err := c.newRequest("GET", "/applicants/"+applicantID+"/checks/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var resp Check
+	var resp CheckRetrieved
 	_, err = c.do(ctx, req, &resp)
 	return &resp, err
+}
+
+// GetCheckExpanded retrieves a check for the provided applicant by its ID, with
+// the Check's Reports expanded within the returned Check object.
+// see https://documentation.onfido.com/?shell#retrieve-check (Shell) but refer to the JSON
+// response object for https://documentation.onfido.com/?php#check-object (PHP) for the expanded contents.
+func (c *Client) GetCheckExpanded(ctx context.Context, applicantID, id string) (*Check, error) {
+	// Get the CheckRetrieved object. This only includes Report IDs, not the expanded Report objects.
+	chkRetrieved, err := c.GetCheck(ctx, applicantID, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a regular Check object, this is what will be returned assuming there is no error.
+	check := Check{
+		CreatedAt:   chkRetrieved.CreatedAt,
+		DownloadURI: chkRetrieved.DownloadURI,
+		FormURI:     chkRetrieved.FormURI,
+		Href:        chkRetrieved.Href,
+		ID:          chkRetrieved.ID,
+		RedirectURI: chkRetrieved.RedirectURI,
+		Reports:     make([]*Report, len(chkRetrieved.Reports)),
+		Result:      chkRetrieved.Result,
+		ResultsURI:  chkRetrieved.ResultsURI,
+		Status:      chkRetrieved.Status,
+		Tags:        chkRetrieved.Tags,
+		Type:        chkRetrieved.Type,
+	}
+
+	// For each Report ID in the CheckRetrieved object, fetch (expand) the Report
+	// into the returned Check object.
+	for i, reportID := range chkRetrieved.Reports {
+		rep, err := c.GetReport(ctx, id, reportID)
+		if err != nil {
+			return nil, err
+		}
+		check.Reports[i] = rep
+	}
+	return &check, nil
 }
 
 // ResumeCheck resumes a paused check by its ID.

--- a/check.go
+++ b/check.go
@@ -55,7 +55,7 @@ type Check struct {
 	FormURI     string      `json:"form_uri,omitempty"`
 	RedirectURI string      `json:"redirect_uri,omitempty"`
 	ResultsURI  string      `json:"results_uri,omitempty"`
-	Reports     []string    `json:"reports,omitempty"`
+	Reports     []*Report   `json:"reports,omitempty"`
 	Tags        []string    `json:"tags,omitempty"`
 }
 

--- a/check_test.go
+++ b/check_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
-	"github.com/uw-labs/go-onfido"
+	onfido "github.com/uw-labs/go-onfido"
 )
 
 func TestCreateCheck_NonOKResponse(t *testing.T) {
@@ -110,7 +110,7 @@ func TestGetCheck_NonOKResponse(t *testing.T) {
 
 func TestGetCheck_CheckRetrieved(t *testing.T) {
 	applicantID := "541d040b-89f8-444b-8921-16b1333bf1c6"
-	expected := onfido.Check{
+	expected := onfido.CheckRetrieved{
 		ID:          "ce62d838-56f8-4ea5-98be-e7166d1dc33d",
 		Href:        "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
 		Type:        onfido.CheckTypeExpress,
@@ -120,14 +120,8 @@ func TestGetCheck_CheckRetrieved(t *testing.T) {
 		FormURI:     "https://onfido.com/information/1234",
 		RedirectURI: "https://somewhere.else",
 		ResultsURI:  "https://onfido.com/dashboard/information_requests/1234",
-		Reports: []*onfido.Report{
-			{
-				ID:     "7410a943-8f00-43d8-98de-36a774196d86",
-				Name:   onfido.ReportNameDocument,
-				Result: onfido.ReportResultClear,
-			},
-		},
-		Tags: []string{"my-tag"},
+		Reports:     []string{"7410a943-8f00-43d8-98de-36a774196d86"},
+		Tags:        []string{"my-tag"},
 	}
 	expectedJson, err := json.Marshal(expected)
 	if err != nil {
@@ -164,6 +158,262 @@ func TestGetCheck_CheckRetrieved(t *testing.T) {
 	assert.Equal(t, expected.FormURI, c.FormURI)
 	assert.Equal(t, expected.RedirectURI, c.RedirectURI)
 	assert.Equal(t, expected.ResultsURI, c.ResultsURI)
+	assert.EqualValues(t, expected.Reports, c.Reports)
+}
+
+func TestGetCheckExpanded_NoReports(t *testing.T) {
+	applicantID := "541d040b-89f8-444b-8921-16b1333bf1c6"
+	expected := onfido.CheckRetrieved{
+		ID:          "ce62d838-56f8-4ea5-98be-e7166d1dc33d",
+		Href:        "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+		Type:        onfido.CheckTypeExpress,
+		Status:      "complete",
+		Result:      onfido.CheckResultClear,
+		DownloadURI: "https://onfido.com/dashboard/pdf/1234",
+		FormURI:     "https://onfido.com/information/1234",
+		RedirectURI: "https://somewhere.else",
+		ResultsURI:  "https://onfido.com/dashboard/information_requests/1234",
+		Reports:     []string{},
+		Tags:        []string{"my-tag"},
+	}
+	expectedJson, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := mux.NewRouter()
+	m.HandleFunc("/applicants/{applicantId}/checks/{checkId}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		assert.Equal(t, applicantID, vars["applicantId"])
+		assert.Equal(t, expected.ID, vars["checkId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(expectedJson)
+	}).Methods("GET")
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	client := onfido.NewClient("123")
+	client.Endpoint = srv.URL
+
+	c, err := client.GetCheckExpanded(context.Background(), applicantID, expected.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected.ID, c.ID)
+	assert.Equal(t, expected.Href, c.Href)
+	assert.Equal(t, expected.Type, c.Type)
+	assert.Equal(t, expected.Status, c.Status)
+	assert.Equal(t, expected.Result, c.Result)
+	assert.Equal(t, expected.DownloadURI, c.DownloadURI)
+	assert.Equal(t, expected.FormURI, c.FormURI)
+	assert.Equal(t, expected.RedirectURI, c.RedirectURI)
+	assert.Equal(t, expected.ResultsURI, c.ResultsURI)
+	assert.Len(t, c.Reports, 0)
+}
+
+func TestGetCheckExpanded_NonOkResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("{\"error\": \"things went bad\"}"))
+	}))
+	defer srv.Close()
+
+	client := onfido.NewClient("123")
+	client.Endpoint = srv.URL
+
+	_, err := client.GetCheckExpanded(context.Background(), "", "")
+	if err == nil {
+		t.Fatal("expected server to return non ok response, got successful response")
+	}
+}
+
+func TestGetCheckExpanded_HasReports(t *testing.T) {
+	applicantID := "541d040b-89f8-444b-8921-16b1333bf1c6"
+	checkID := "ce62d838-56f8-4ea5-98be-e7166d1dc33d"
+	report1ID := "1fd6fec0-456f-443a-b75d-b048f47c34f7"
+	report2ID := "6ec6c029-469e-4c9e-91f3-beeb3fbc175e"
+
+	expected := onfido.CheckRetrieved{
+		ID:          checkID,
+		Href:        "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+		Type:        onfido.CheckTypeExpress,
+		Status:      "complete",
+		Result:      onfido.CheckResultClear,
+		DownloadURI: "https://onfido.com/dashboard/pdf/1234",
+		FormURI:     "https://onfido.com/information/1234",
+		RedirectURI: "https://somewhere.else",
+		ResultsURI:  "https://onfido.com/dashboard/information_requests/1234",
+		Reports:     []string{report1ID, report2ID},
+		Tags:        []string{"my-tag"},
+	}
+	expectedJson, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expected Report 1
+	expectedReport1 := onfido.Report{
+		ID:        report1ID,
+		Name:      onfido.ReportNameDocument,
+		Status:    "complete",
+		Result:    onfido.ReportResultClear,
+		SubResult: onfido.ReportSubResultClear,
+		Variant:   onfido.ReportVariantStandard,
+		Href:      "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+	}
+	expectedReport1Json, err := json.Marshal(expectedReport1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expected Report 2
+	expectedReport2 := onfido.Report{
+		ID:        report2ID,
+		Name:      onfido.ReportNameDocument,
+		Status:    "complete",
+		Result:    onfido.ReportResultClear,
+		SubResult: onfido.ReportSubResultClear,
+		Variant:   onfido.ReportVariantStandard,
+		Href:      "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+	}
+	expectedReport2Json, err := json.Marshal(expectedReport2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := mux.NewRouter()
+	// Return the requested Report
+	m.HandleFunc("/checks/{checkId}/reports/{reportId}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		assert.Equal(t, checkID, vars["checkId"])
+		assert.Contains(t, expected.Reports, vars["reportId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		switch vars["reportId"] {
+		case report1ID:
+			w.Write(expectedReport1Json)
+		case report2ID:
+			w.Write(expectedReport2Json)
+		}
+	}).Methods("GET")
+
+	// Return the requested Check
+	m.HandleFunc("/applicants/{applicantId}/checks/{checkId}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		assert.Equal(t, applicantID, vars["applicantId"])
+		assert.Equal(t, expected.ID, vars["checkId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(expectedJson)
+	}).Methods("GET")
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	client := onfido.NewClient("123")
+	client.Endpoint = srv.URL
+
+	c, err := client.GetCheckExpanded(context.Background(), applicantID, expected.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected.ID, c.ID)
+	assert.Equal(t, expected.Href, c.Href)
+	assert.Equal(t, expected.Type, c.Type)
+	assert.Equal(t, expected.Status, c.Status)
+	assert.Equal(t, expected.Result, c.Result)
+	assert.Equal(t, expected.DownloadURI, c.DownloadURI)
+	assert.Equal(t, expected.FormURI, c.FormURI)
+	assert.Equal(t, expected.RedirectURI, c.RedirectURI)
+	assert.Equal(t, expected.ResultsURI, c.ResultsURI)
+	assert.Len(t, c.Reports, 2)
+	assert.ElementsMatch(t, c.Reports, []*onfido.Report{&expectedReport1, &expectedReport2})
+}
+
+func TestGetCheckExpanded_HasReports_NonOkResponse(t *testing.T) {
+	applicantID := "541d040b-89f8-444b-8921-16b1333bf1c6"
+	checkID := "ce62d838-56f8-4ea5-98be-e7166d1dc33d"
+	report1ID := "1fd6fec0-456f-443a-b75d-b048f47c34f7"
+	report2ID := "returns-error-status"
+
+	expected := onfido.CheckRetrieved{
+		ID:          checkID,
+		Href:        "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+		Type:        onfido.CheckTypeExpress,
+		Status:      "complete",
+		Result:      onfido.CheckResultClear,
+		DownloadURI: "https://onfido.com/dashboard/pdf/1234",
+		FormURI:     "https://onfido.com/information/1234",
+		RedirectURI: "https://somewhere.else",
+		ResultsURI:  "https://onfido.com/dashboard/information_requests/1234",
+		Reports:     []string{report1ID, report2ID},
+		Tags:        []string{"my-tag"},
+	}
+	expectedJson, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expected Report 1
+	expectedReport1 := onfido.Report{
+		ID:        report1ID,
+		Name:      onfido.ReportNameDocument,
+		Status:    "complete",
+		Result:    onfido.ReportResultClear,
+		SubResult: onfido.ReportSubResultClear,
+		Variant:   onfido.ReportVariantStandard,
+		Href:      "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+	}
+	expectedReport1Json, err := json.Marshal(expectedReport1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := mux.NewRouter()
+	// Return the requested Report
+	m.HandleFunc("/checks/{checkId}/reports/{reportId}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		assert.Equal(t, checkID, vars["checkId"])
+		assert.Contains(t, expected.Reports, vars["reportId"])
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch vars["reportId"] {
+		case report1ID:
+			w.WriteHeader(http.StatusOK)
+			w.Write(expectedReport1Json)
+		case report2ID:
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("{\"error\": \"things went bad\"}"))
+		}
+	}).Methods("GET")
+
+	// Return the requested Check
+	m.HandleFunc("/applicants/{applicantId}/checks/{checkId}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		assert.Equal(t, applicantID, vars["applicantId"])
+		assert.Equal(t, expected.ID, vars["checkId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(expectedJson)
+	}).Methods("GET")
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	client := onfido.NewClient("123")
+	client.Endpoint = srv.URL
+
+	_, err = client.GetCheckExpanded(context.Background(), applicantID, expected.ID)
+	if err == nil {
+		t.Fatal("expected server to return non ok response, got successful response")
+	}
 }
 
 func TestResumeCheck_NonOKResponse(t *testing.T) {

--- a/report.go
+++ b/report.go
@@ -12,6 +12,7 @@ const (
 	ReportNameDocument         ReportName = "document"
 	ReportNameFacialSimilarity ReportName = "facial_similarity"
 	ReportNameStreetLevel      ReportName = "street_level"
+	ReportNameProofOfAddress   ReportName = "proof_of_address"
 
 	ReportResultClear        ReportResult = "clear"
 	ReportResultConsider     ReportResult = "consider"


### PR DESCRIPTION
Hah! This typo left me with a bit of a headscratcher for a while as I tried to figure out why I kept getting this:

```
go get github.com/uw-labs/go-onfio: git ls-remote -q https://github.com/uw-labs/go-onfio in $GOPATH/go/pkg/mod/cache/vcs/1af16ce6d695c633d01f209fcec15696b74d7ed4615ee5d5e9b89be33c9ab967: exit status 128:
        fatal: could not read Username for 'https://github.com': terminal prompts disabled
If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
```