### PR TITLE
Updating check struct

### DIFF
--- a/check.go
+++ b/check.go
@@ -55,7 +55,7 @@ type Check struct {
 	FormURI     string      `json:"form_uri,omitempty"`
 	RedirectURI string      `json:"redirect_uri,omitempty"`
 	ResultsURI  string      `json:"results_uri,omitempty"`
-	Reports     []*Report   `json:"reports,omitempty"`
+	Reports     []string    `json:"reports,omitempty"`
 	Tags        []string    `json:"tags,omitempty"`
 }
 


### PR DESCRIPTION
Looks like the Onfido API has changed the [check object](https://documentation.onfido.com/#check-object) to return a list of report IDs (rather than complete report objects). This PR fixes this discrepency, which was previously causing the following error (for anyone currently running into it):

```
json: cannot unmarshal string into Go struct field Check.reports of type onfido.Report
```