### PR TITLE
Refined typing for Onfido Report Breakdown and Properties fields

### DIFF
--- a/breakdown.go
+++ b/breakdown.go
@@ -1,0 +1,30 @@
+package onfido
+
+const (
+	BreakdownClear    BreakdownResult = "clear"
+	BreakdownConsider BreakdownResult = "consider"
+
+	SubBreakdownClear        BreakdownSubResult = "clear"
+	SubBreakdownConsider     BreakdownSubResult = "consider"
+	SubBreakdownUnidentified BreakdownSubResult = "unidentified"
+)
+
+// BreakdownResult represents a report's breakdown result
+type BreakdownResult string
+
+// BreakdownSubResult represents a report's sub-breakdown result
+type BreakdownSubResult string
+
+type Breakdowns map[string]Breakdown
+
+type Breakdown struct {
+	Result        *BreakdownResult `json:"result"`
+	SubBreakdowns SubBreakdowns    `json:"breakdown"`
+}
+
+type SubBreakdowns map[string]SubBreakdown
+
+type SubBreakdown struct {
+	Result     *BreakdownSubResult `json:"result"`
+	Properties Properties          `json:"properties"`
+}

--- a/properties.go
+++ b/properties.go
@@ -1,0 +1,3 @@
+package onfido
+
+type Properties map[string]interface{}

--- a/report.go
+++ b/report.go
@@ -55,22 +55,6 @@ type Report struct {
 	Properties Properties             `json:"properties,omitempty"`
 }
 
-type Properties map[string]interface{}
-
-type Breakdowns map[string]Breakdown
-
-type Breakdown struct {
-	Result        string        `json:"result"`
-	SubBreakdowns SubBreakdowns `json:"breakdown"`
-}
-
-type SubBreakdowns map[string]SubBreakdown
-
-type SubBreakdown struct {
-	Result     string     `json:"result"`
-	Properties Properties `json:"properties"`
-}
-
 // Reports represents a list of reports from the Onfido API
 type Reports struct {
 	Reports []*Report `json:"reports"`

--- a/report.go
+++ b/report.go
@@ -51,8 +51,24 @@ type Report struct {
 	Variant    ReportVariant          `json:"variant,omitempty"`
 	Href       string                 `json:"href,omitempty"`
 	Options    map[string]interface{} `json:"options,omitempty"`
-	Breakdown  map[string]interface{} `json:"breakdown,omitempty"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	Breakdown  Breakdowns             `json:"breakdown,omitempty"`
+	Properties Properties             `json:"properties,omitempty"`
+}
+
+type Properties map[string]interface{}
+
+type Breakdowns map[string]Breakdown
+
+type Breakdown struct {
+	Result        string        `json:"result"`
+	SubBreakdowns SubBreakdowns `json:"breakdown"`
+}
+
+type SubBreakdowns map[string]SubBreakdown
+
+type SubBreakdown struct {
+	Result     string     `json:"result"`
+	Properties Properties `json:"properties"`
 }
 
 // Reports represents a list of reports from the Onfido API

--- a/report_test.go
+++ b/report_test.go
@@ -28,7 +28,7 @@ func TestGetReport_NonOKResponse(t *testing.T) {
 	}
 }
 
-func TestGetReport_ReportRetrieved(t *testing.T) {
+func TestGetReport_ReportRetrieved_Clear(t *testing.T) {
 	checkID := "541d040b-89f8-444b-8921-16b1333bf1c6"
 	expected := onfido.Report{
 		ID:        "ce62d838-56f8-4ea5-98be-e7166d1dc33d",
@@ -38,6 +38,10 @@ func TestGetReport_ReportRetrieved(t *testing.T) {
 		SubResult: onfido.ReportSubResultClear,
 		Variant:   onfido.ReportVariantStandard,
 		Href:      "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+		Properties: onfido.Properties{
+			"document_type":   "passport",
+			"issuing_country": "GBR",
+		},
 	}
 	expectedJson, err := json.Marshal(expected)
 	if err != nil {
@@ -72,6 +76,90 @@ func TestGetReport_ReportRetrieved(t *testing.T) {
 	assert.Equal(t, expected.SubResult, r.SubResult)
 	assert.Equal(t, expected.Variant, r.Variant)
 	assert.Equal(t, expected.Href, r.Href)
+	assert.Zero(t, r.Breakdown)
+	assert.NotZero(t, r.Properties)
+	assert.Contains(t, r.Properties, "document_type")
+	assert.Equal(t, "passport", r.Properties["document_type"])
+	assert.Contains(t, r.Properties, "issuing_country")
+	assert.Equal(t, "GBR", r.Properties["issuing_country"])
+}
+
+func TestGetReport_ReportRetrieved_Consider(t *testing.T) {
+	checkID := "541d040b-89f8-444b-8921-16b1333bf1c6"
+	breakdownResultConsider := onfido.BreakdownResult(onfido.ReportResultConsider)
+	breakdownSubResultConsider := onfido.BreakdownSubResult(onfido.ReportResultConsider)
+	breakdownSubResultClear := onfido.BreakdownSubResult(onfido.ReportResultClear)
+	expected := onfido.Report{
+		ID:        "ce62d838-56f8-4ea5-98be-e7166d1dc33d",
+		Name:      onfido.ReportNameDocument,
+		Status:    "complete",
+		Result:    onfido.ReportResultConsider,
+		SubResult: onfido.ReportSubResultRejected,
+		Variant:   onfido.ReportVariantStandard,
+		Href:      "/v2/live_photos/7410A943-8F00-43D8-98DE-36A774196D86",
+		Breakdown: onfido.Breakdowns{
+			"image_integrity": onfido.Breakdown{
+				Result: &breakdownResultConsider,
+				SubBreakdowns: onfido.SubBreakdowns{
+					"image_quality": onfido.SubBreakdown{
+						Result: &breakdownSubResultConsider,
+						Properties: onfido.Properties{
+							"alpha": "one",
+							"beta":  "two",
+						},
+					},
+					"supported_document": {
+						Result: &breakdownSubResultClear,
+					},
+				},
+			},
+		},
+	}
+	expectedJson, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := mux.NewRouter()
+	m.HandleFunc("/checks/{checkId}/reports/{reportId}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		assert.Equal(t, checkID, vars["checkId"])
+		assert.Equal(t, expected.ID, vars["reportId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(expectedJson)
+	}).Methods("GET")
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	client := onfido.NewClient("123")
+	client.Endpoint = srv.URL
+
+	r, err := client.GetReport(context.Background(), checkID, expected.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected.ID, r.ID)
+	assert.Equal(t, expected.Name, r.Name)
+	assert.Equal(t, expected.Status, r.Status)
+	assert.Equal(t, expected.Result, r.Result)
+	assert.Equal(t, expected.SubResult, r.SubResult)
+	assert.Equal(t, expected.Variant, r.Variant)
+	assert.Equal(t, expected.Href, r.Href)
+	assert.Len(t, r.Breakdown, 1)
+	assert.Contains(t, r.Breakdown, "image_integrity")
+	assert.Contains(t, r.Breakdown["image_integrity"].SubBreakdowns, "image_quality")
+	assert.Equal(t, breakdownSubResultConsider, *r.Breakdown["image_integrity"].SubBreakdowns["image_quality"].Result)
+	assert.NotZero(t, r.Breakdown["image_integrity"].SubBreakdowns["image_quality"].Properties)
+	assert.Contains(t, r.Breakdown["image_integrity"].SubBreakdowns["image_quality"].Properties, "alpha")
+	assert.Contains(t, r.Breakdown["image_integrity"].SubBreakdowns["image_quality"].Properties["alpha"], "one")
+	assert.Contains(t, r.Breakdown["image_integrity"].SubBreakdowns["image_quality"].Properties, "beta")
+	assert.Contains(t, r.Breakdown["image_integrity"].SubBreakdowns["image_quality"].Properties["beta"], "two")
+	assert.Contains(t, r.Breakdown["image_integrity"].SubBreakdowns, "supported_document")
+	assert.Equal(t, breakdownSubResultClear, *r.Breakdown["image_integrity"].SubBreakdowns["supported_document"].Result)
+	assert.Zero(t, r.Breakdown["image_integrity"].SubBreakdowns["supported_document"].Properties)
 }
 
 func TestResumeReport_NonOKResponse(t *testing.T) {


### PR DESCRIPTION
I had a need to interrogate the Onfido Report JSON structure within Go, in particular the Breakdown and Properties fields. To do this successfully I needed to refine the Breakdown typing from map[string]interface{} into a new Go type which correlates to the Onfido JSON structure.
Unit tests have been added to cover the new types.
In-house testing with actual Reports from Onfido has been successful.
The Properties type remains a map[string]interface although it appears to be a map[string]string in the example Onfido JSON and from my testing. This is easy enough to type assert in Go, so I left it unchanged for now, but have moved it into a separate file in case future type refinements are required.
