### PR TITLE
Added "unidentified" breakdown result type

### DIFF
--- a/breakdown.go
+++ b/breakdown.go
@@ -1,8 +1,9 @@
 package onfido
 
 const (
-	BreakdownClear    BreakdownResult = "clear"
-	BreakdownConsider BreakdownResult = "consider"
+	BreakdownClear        BreakdownResult = "clear"
+	BreakdownConsider     BreakdownResult = "consider"
+	BreakdownUnidentified BreakdownResult = "unidentified"
 
 	SubBreakdownClear        BreakdownSubResult = "clear"
 	SubBreakdownConsider     BreakdownSubResult = "consider"


### PR DESCRIPTION
This was seen in a live Onfido Identity Check Report. I believe this is the only kind of Onfido Check which can use it.