### PR TITLE
add module files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/uw-labs/go-onfido
+
+go 1.12
+
+require github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=


### PR DESCRIPTION
Add go module files. This is needed so that a go-modules enabled dependee can refer to a version of the project checked out in the workspace.