### PR TITLE
To aid testing, verification is configurable

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -25,7 +25,8 @@ var (
 
 // Webhook represents a webhook handler
 type Webhook struct {
-	Token string
+	Token                   string
+	SkipSignatureValidation bool
 }
 
 // WebhookRequest represents an incoming webhook request from Onfido
@@ -84,8 +85,10 @@ func (wh *Webhook) ParseFromRequest(req *http.Request) (*WebhookRequest, error) 
 	}
 	defer req.Body.Close()
 
-	if err := wh.ValidateSignature(body, signature); err != nil {
-		return nil, err
+	if !wh.SkipSignatureValidation {
+		if err := wh.ValidateSignature(body, signature); err != nil {
+			return nil, err
+		}
 	}
 
 	var wr WebhookRequest

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -58,7 +58,7 @@ func TestParseFromRequest_InvalidSignature(t *testing.T) {
 		Header: make(map[string][]string),
 	}
 	req.Header.Add(onfido.WebhookSignatureHeader, "123")
-	req.Body = ioutil.NopCloser(bytes.NewBuffer([]byte("hello world")))
+	req.Body = ioutil.NopCloser(bytes.NewBuffer([]byte("{\"msg\": \"hello world\"}")))
 
 	wh := onfido.Webhook{Token: "abc123"}
 	_, err := wh.ParseFromRequest(req)
@@ -67,6 +67,19 @@ func TestParseFromRequest_InvalidSignature(t *testing.T) {
 	}
 	if err != onfido.ErrInvalidWebhookSignature {
 		t.Fatal("expected error to match ErrInvalidWebhookSignature")
+	}
+}
+
+func TestParseFromRequest_SkipSignatureValidation(t *testing.T) {
+	req := &http.Request{
+		Header: make(map[string][]string),
+	}
+	req.Body = ioutil.NopCloser(bytes.NewBuffer([]byte("{\"msg\": \"hello world\"}")))
+
+	wh := onfido.Webhook{Token: "abc123", SkipSignatureValidation: true}
+	_, err := wh.ParseFromRequest(req)
+	if err != nil {
+		t.Errorf("expected no error as signature validation should have been skipped: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
Allow signature verification to be configurable. 

The default is kept to verify to stop accidentally switching off verification and not knowing. 