### PR TITLE
Add support for new token formats

### DIFF
--- a/onfido.go
+++ b/onfido.go
@@ -68,7 +68,8 @@ func (t Token) String() string {
 
 // Prod checks if this is a production token or not.
 func (t Token) Prod() bool {
-	return !strings.HasPrefix(string(t), "test_")
+	return !strings.HasPrefix(string(t), "test_") &&
+		!strings.HasPrefix(string(t), "api_sandbox.")
 }
 
 // NewClientFromEnv creates a new Onfido client using configuration

--- a/onfido_test.go
+++ b/onfido_test.go
@@ -49,6 +49,8 @@ func TestToken_IsProd(t *testing.T) {
 		{"prod_122333", true},
 		{"122333", true},
 		{"test_122333", false},
+		{"api_live.122333", true},
+		{"api_sandbox.122333", false},
 	}
 
 	for _, expected := range tokens {


### PR DESCRIPTION
This updates the `token.Prod()` method to recognize the new Production token format, while leaving the checks for the old format intact.

Closes #40 